### PR TITLE
Added norm=colors.NoNorm() to ColorbarBase for Significance Plots

### DIFF
--- a/scikit_posthocs/_plotting.py
+++ b/scikit_posthocs/_plotting.py
@@ -1,10 +1,12 @@
 from typing import Union, List, Tuple
+
 import numpy as np
-from matplotlib.colors import ListedColormap
-from matplotlib.colorbar import ColorbarBase, Colorbar
+from matplotlib import colors
 from matplotlib.axes import SubplotBase
-from seaborn import heatmap
+from matplotlib.colorbar import ColorbarBase, Colorbar
+from matplotlib.colors import ListedColormap
 from pandas import DataFrame
+from seaborn import heatmap
 
 
 def sign_array(
@@ -88,8 +90,8 @@ def sign_table(
     if not any([lower, upper]):
         raise ValueError("Either lower or upper triangle must be returned")
 
-    pv = DataFrame(p_values, copy=True)\
-        if not isinstance(p_values, DataFrame)\
+    pv = DataFrame(p_values, copy=True) \
+        if not isinstance(p_values, DataFrame) \
         else p_values.copy()
 
     ns = pv > 0.05
@@ -240,9 +242,9 @@ def sign_plot(
             hax.set_ylabel('')
 
         cbar_ax = hax.figure.add_axes(cbar_ax_bbox or [0.95, 0.35, 0.04, 0.3])
-        cbar = ColorbarBase(cbar_ax, cmap=ListedColormap(cmap[2:] + [cmap[1]]),
+        cbar = ColorbarBase(cbar_ax, cmap=(ListedColormap(cmap[2:] + [cmap[1]])), norm=colors.NoNorm(),
                             boundaries=[0, 1, 2, 3, 4])
-        cbar.set_ticks(np.linspace(0.5, 3.5, 4))
+        cbar.set_ticks(list(np.linspace(0.5, 3.5, 4)))
         cbar.set_ticklabels(['p < 0.001', 'p < 0.01', 'p < 0.05', 'NS'])
 
         cbar.outline.set_linewidth(1)
@@ -250,4 +252,3 @@ def sign_plot(
         cbar.ax.tick_params(size=0)
 
         return hax, cbar
-

--- a/scikit_posthocs/_plotting.py
+++ b/scikit_posthocs/_plotting.py
@@ -244,8 +244,7 @@ def sign_plot(
         cbar_ax = hax.figure.add_axes(cbar_ax_bbox or [0.95, 0.35, 0.04, 0.3])
         cbar = ColorbarBase(cbar_ax, cmap=(ListedColormap(cmap[2:] + [cmap[1]])), norm=colors.NoNorm(),
                             boundaries=[0, 1, 2, 3, 4])
-        cbar.set_ticks(list(np.linspace(0.5, 3.5, 4)))
-        cbar.set_ticklabels(['p < 0.001', 'p < 0.01', 'p < 0.05', 'NS'])
+        cbar.set_ticks(list(np.linspace(0, 3, 4)), labels=['p < 0.001', 'p < 0.01', 'p < 0.05', 'NS'])
 
         cbar.outline.set_linewidth(1)
         cbar.outline.set_edgecolor('0.5')


### PR DESCRIPTION
A quick fix for Issue #51 is by adding norm=colors.NoNorm() to ColorbarBase. Probably should be double-checked to ensure the behaviour is correct for all cases.

```
import matplotlib.pyplot as plt
import scikit_posthocs as sp
import statsmodels.api as sa

x = sa.datasets.get_rdataset('iris').data
x.columns = x.columns.str.replace('.', '')
pc = sp.posthoc_ttest(x, val_col='SepalWidth', group_col='Species', p_adjust='holm')
heatmap_args = {'linewidths': 0.25, 'linecolor': '0.5', 'clip_on': False, 'square': True,
                'cbar_ax_bbox': [0.82, 0.35, 0.04, 0.3]}
sp.sign_plot(pc, **heatmap_args)
plt.show()
```

![expected](https://user-images.githubusercontent.com/5563995/153777979-fadef436-a300-466a-82cb-842eac038b18.png)