### PR TITLE
Outlier gesd

### DIFF
--- a/scikit_posthocs/_outliers.py
+++ b/scikit_posthocs/_outliers.py
@@ -300,6 +300,12 @@ def outliers_gesd(
     data = data_proc[argsort_index]
     n = data_proc.size
 
+    # Lambda values (critical values): do not depend on the outliers.
+    nol = np.arange(outliers)  # the number of outliers
+    df = n - nol - 2  # degrees of freedom
+    t_ppr = t.ppf(1 - alpha / (2 * (n - nol)), df)
+    ls = ((n - nol - 1) * t_ppr) / np.sqrt((df + t_ppr**2) * (n - nol))
+
     for i in np.arange(outliers):
 
         abs_d = np.abs(data_proc - np.mean(data_proc))
@@ -312,14 +318,6 @@ def outliers_gesd(
         lms = ms[-1] if len(ms) > 0 else []
         ms.append(
             lms + np.where(data == data_proc[np.argmax(abs_d)])[0].tolist())
-
-        # Lambdas calculation
-        p = 1 - alpha / (2 * (n - i))
-        df = n - i - 2
-        t_ppr = t.ppf(p, df)
-        lambd = ((n - i - 1) * t_ppr) /\
-            np.sqrt((n - i - 2 + t_ppr**2) * (n - i))
-        ls[i] = lambd
 
         # Remove the observation that maximizes |xi − xmean|
         data_proc = np.delete(data_proc, np.argmax(abs_d))

--- a/scikit_posthocs/_outliers.py
+++ b/scikit_posthocs/_outliers.py
@@ -332,7 +332,7 @@ def outliers_gesd(
                   "---------------------------------------",
                   "      Exact           Test     Critical",
                   "  Number of      Statistic    Value, λi",
-                  "Outliers, i      Value, Ri          5 %",
+                  "Outliers, i      Value, Ri      {:5.3g} %".format(100*alpha),
                   "---------------------------------------"]
 
         for i, (r, l) in enumerate(zip(rs, ls)):


### PR DESCRIPTION
1. The lambda value (critical value) array was initialized and calculation was done **inside** the for-loop, which slows down the calculation. As this array is **independent** of outlier values, I took it out of the loop.
2. The report string was hard-coded for Critical Value (``"5%"``). Following the original intention, I used a formatted string with ``{:5.3g}`` to accommodate with general ``alpha`` values.

I checked the updated version passed ``tests/test_posthocs.py``, and the "report" was identical for all the following test cases below.

## Timing
Especially due to the first part, the test case got 2.x times faster(``outliers_gesd2`` is the updated version of the function):

```python
data = np.array([-0.25, 0.68, 0.94, 1.15, 1.2, 1.26, 1.26, 1.34,
        1.38, 1.43, 1.49, 1.49, 1.55, 1.56, 1.58, 1.65, 1.69, 1.7, 1.76,
        1.77, 1.81, 1.91, 1.94, 1.96, 1.99, 2.06, 2.09, 2.1, 2.14, 2.15,
        2.23, 2.24, 2.26, 2.35, 2.37, 2.4, 2.47, 2.54, 2.62, 2.64, 2.9,
        2.92, 2.92, 2.93, 3.21, 3.26, 3.3, 3.59, 3.68, 4.3, 4.64, 5.34,
        5.42, 6.01])
np.testing.assert_array_almost_equal(outliers_gesd(data, 5), outliers_gesd2(data, 5))
%timeit outliers_gesd(data, 5)
%timeit outliers_gesd2(data, 5)
```
```
389 µs ± 8.41 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
173 µs ± 2.34 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

When there are more outliers, the difference gets larger (speed boost ~ 3 times):

```python
data[:10] *= 10
outliers = 15
np.testing.assert_array_almost_equal(outliers_gesd(data, outliers), outliers_gesd2(data, outliers))

%timeit outliers_gesd(data, outliers)
%timeit outliers_gesd2(data, outliers)
```
```
1.12 ms ± 21.1 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
398 µs ± 3.66 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

(tested on MBP 14" [2021, macOS 12.2.1, M1Pro(6P+2E/G16c/N16c/32G)])