### PR TITLE
use .loc instead of list indexing for ranks

### DIFF
--- a/scikit_posthocs/_plotting.py
+++ b/scikit_posthocs/_plotting.py
@@ -530,7 +530,7 @@ def critical_difference_diagram(
 
     # Sort by lowest rank and filter single-valued sets
     crossbar_sets = sorted(
-        (x for x in crossbar_sets if len(x) > 1), key=lambda x: ranks[list(x)].min()
+        (x for x in crossbar_sets if len(x) > 1), key=lambda x: ranks.loc[list(x)].min()
     )
 
     # Create stacking of crossbars: for each level, try to fit the crossbar,


### PR DESCRIPTION
Fix remaining occurrences of deprecated list indexing in pandas 
Sorry, I missed this aparition (first issued in https://github.com/maximtrp/scikit-posthocs/pull/94)