### PR TITLE
Preserve observation pairs when sorting Wilcoxon groups

### DIFF
--- a/scikit_posthocs/_posthocs.py
+++ b/scikit_posthocs/_posthocs.py
@@ -2191,7 +2191,7 @@ def posthoc_wilcoxon(
         'fdr_tsbky' : two stage fdr correction (non-negative)
 
     sort : bool, optional
-        Specifies whether to sort DataFrame by group_col and val_col or not.
+        Sort groups while preserving the input order of observations within each group.
         Default is False.
 
     Returns
@@ -2201,6 +2201,8 @@ def posthoc_wilcoxon(
 
     Notes
     -----
+    Observations are paired by their input order within each group. Callers must
+    align the pairs before passing the data. Sorting only changes group order.
     Refer to `scipy.stats.wilcoxon` reference page for further details [1]_.
 
     References
@@ -2213,7 +2215,7 @@ def posthoc_wilcoxon(
     >>> sp.posthoc_wilcoxon(x)
     """
     x, _val_col, _group_col = __convert_to_df(a, val_col, group_col)
-    x = x.sort_values(by=[_group_col, _val_col], ascending=True) if sort else x
+    x = x.sort_values(by=_group_col, kind="stable") if sort else x
 
     groups = x[_group_col].unique()
     x_len = groups.size

--- a/tests/test_wilcoxon_pair_order.py
+++ b/tests/test_wilcoxon_pair_order.py
@@ -34,4 +34,4 @@ def test_wilcoxon_group_sort_preserves_subject_pairs(sort, input_type, method, a
     actual = posthoc_wilcoxon(data, sort=sort, method=method, p_adjust=adjust, **kwargs)
     for (i, j), p_value in zip([(0, 1), (0, 2), (1, 2)], expected):
         np.testing.assert_allclose(actual.loc[labels[i], labels[j]], p_value)
-    assert actual.index.tolist() == (sorted(labels) if sort else labels)
+    np.testing.assert_array_equal(actual.index, sorted(labels) if sort else labels)

--- a/tests/test_wilcoxon_pair_order.py
+++ b/tests/test_wilcoxon_pair_order.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pandas as pd
+import pytest
+from scipy.stats import wilcoxon
+from statsmodels.stats.multitest import multipletests
+
+from scikit_posthocs import posthoc_wilcoxon
+
+
+@pytest.mark.parametrize("sort", [False, True])
+@pytest.mark.parametrize("input_type", ["list", "array", "dataframe"])
+@pytest.mark.parametrize("method", ["auto", "exact"])
+@pytest.mark.parametrize("adjust", [None, "holm"])
+def test_wilcoxon_group_sort_preserves_subject_pairs(sort, input_type, method, adjust):
+    x = 2 * np.arange(40)
+    samples = [x, x[::-1] + 1, np.roll(x, 9) + 3]
+    labels = ["c", "a", "b"] if input_type == "dataframe" else [1, 2, 3]
+    kwargs = {}
+    if input_type == "dataframe":
+        # Interleave groups, while retaining each subject's order within a group.
+        data = (
+            pd.DataFrame(np.asarray(samples).T, columns=labels)
+            .melt(var_name="group", value_name="value", ignore_index=False)
+            .sort_index(kind="stable")
+        )
+        kwargs = {"val_col": "value", "group_col": "group"}
+    else:
+        data = np.asarray(samples) if input_type == "array" else samples
+    expected = [
+        wilcoxon(samples[i], samples[j], method=method).pvalue for i, j in [(0, 1), (0, 2), (1, 2)]
+    ]
+    if adjust:
+        expected = multipletests(expected, method=adjust)[1]
+    actual = posthoc_wilcoxon(data, sort=sort, method=method, p_adjust=adjust, **kwargs)
+    for (i, j), p_value in zip([(0, 1), (0, 2), (1, 2)], expected):
+        np.testing.assert_allclose(actual.loc[labels[i], labels[j]], p_value)
+    assert actual.index.tolist() == (sorted(labels) if sort else labels)


### PR DESCRIPTION
`posthoc_wilcoxon(sort=True)` sorts by both group and measured value. Sorting each sample separately changes the observation pairs before applying the signed-rank test. The option can therefore change the hypothesis test rather than only group presentation.

Sort stably by group alone, preserving each group's original observation order. Document that observations are paired by their within-group input order and callers must align them before calling the function. The default `sort=False` behaviour is preserved.

Reproduction with 40 pairs: `x = 2*np.arange(40)` and `y = x[::-1] + 1`. With `method='exact'`, `sort=False` and direct SciPy give p=0.8995151304461615. The original `sort=True` gives p=1.8189894035458565e-12: independent sorting makes every difference equal to -1. An exact signed-rank subset-sum calculation confirms the original-pair reference. This is a constructed counterexample, not a published-dataset or paper reanalysis.

Validation on base `f59c84509515a4562f37a9048e0eeaf35f7af9c9`: 24 new cases cover list, ndarray and interleaved DataFrame input; sort on/off; auto/exact methods; and unadjusted/Holm results. Before: 12 fail, 12 pass. After: 24 new cases plus the existing Wilcoxon test pass (**25 passed**, 95 deselected). Released 0.16.1 also reproduces the error. Full package suite not run.

Prepared with AI assistance. Independent review and maintainer acceptance are not claimed. The [Cheerful Duck report](https://cheerfulduck.com/research/audits/scikit-posthocs-wilcoxon-pair-order) provides the reproduction script, separate patches, environment records and before/after execution evidence in a downloadable archive.
