### PR TITLE
Exclude missing observations from Dunn sample size and ranking

### DIFF
--- a/scikit_posthocs/_posthocs.py
+++ b/scikit_posthocs/_posthocs.py
@@ -372,7 +372,8 @@ def posthoc_dunn(
 
     Notes
     -----
-    A tie correction will be employed according to Glantz (2012).
+    A tie correction will be employed according to Glantz (2012). Rows with a
+    missing value or group label are excluded before ranking and counting.
 
     References
     ----------
@@ -388,6 +389,7 @@ def posthoc_dunn(
     """
 
     x, _val_col, _group_col = __convert_to_df(a, val_col, group_col)
+    x = x.dropna(subset=[_val_col, _group_col])
     x = x.sort_values(by=[_group_col, _val_col], ascending=True) if sort else x
 
     n = len(x.index)

--- a/scikit_posthocs/_posthocs.py
+++ b/scikit_posthocs/_posthocs.py
@@ -258,7 +258,8 @@ def posthoc_conover(
 
     Notes
     -----
-    A tie correction are employed according to Conover [1]_.
+    A tie correction is employed according to Conover [1]_. Rows with a missing
+    value or group label are excluded before ranking and counting.
 
     References
     ----------
@@ -272,6 +273,7 @@ def posthoc_conover(
     """
 
     x, _val_col, _group_col = __convert_to_df(a, val_col, group_col)
+    x = x.dropna(subset=[_val_col, _group_col])
     x = x.sort_values(by=[_group_col, _val_col], ascending=True) if sort else x
 
     n = len(x.index)
@@ -469,7 +471,8 @@ def posthoc_nemenyi(
 
     Notes
     -----
-    A tie correction will be employed according to Glantz (2012).
+    A tie correction will be employed according to Glantz (2012). Rows with a
+    missing value or group label are excluded before ranking and counting.
 
     References
     ----------
@@ -483,6 +486,7 @@ def posthoc_nemenyi(
     """
 
     x, _val_col, _group_col = __convert_to_df(a, val_col, group_col)
+    x = x.dropna(subset=[_val_col, _group_col])
     x = x.sort_values(by=[_group_col, _val_col], ascending=True) if sort else x
 
     n = len(x.index)

--- a/tests/test_dunn_missing_values.py
+++ b/tests/test_dunn_missing_values.py
@@ -3,7 +3,9 @@ import pandas as pd
 import pytest
 from scipy.stats import mannwhitneyu
 
-from scikit_posthocs import posthoc_dunn
+from scikit_posthocs import posthoc_conover, posthoc_dunn, posthoc_nemenyi
+
+RANK_POSTHOCS = [posthoc_conover, posthoc_dunn, posthoc_nemenyi]
 
 
 @pytest.mark.parametrize("padding", [0, 1, 20])
@@ -30,8 +32,54 @@ def test_dunn_missing_values_do_not_change_two_group_reference(padding, input_ty
 
 def test_dunn_missing_group_is_excluded_before_ranking():
     data = pd.DataFrame(
-        {"value": [1, 2, 3, 4, 5, 6, 1000], "group": ["a", "a", "a", "b", "b", "b", None]}
+        {
+            "value": [1, 2, 3, 4, 5, 6, 1000],
+            "group": ["a", "a", "a", "b", "b", "b", None],
+        }
     )
     expected = posthoc_dunn(data.dropna(), val_col="value", group_col="group", p_adjust="holm")
     actual = posthoc_dunn(data, val_col="value", group_col="group", p_adjust="holm")
+    pd.testing.assert_frame_equal(actual, expected)
+
+
+@pytest.mark.parametrize("function", RANK_POSTHOCS)
+@pytest.mark.parametrize("input_type", ["list", "array", "dataframe"])
+@pytest.mark.parametrize("sort", [False, True])
+def test_rank_posthoc_missing_values_match_complete_input(function, input_type, sort):
+    samples = [[1, 2, 2, 4, 5, 8], [3, 5, 5, 6, 9, 10], [2, 4, 7, 7, 8, 12]]
+    padded = [group + [np.nan] * (i + 1) for i, group in enumerate(samples)]
+    kwargs = {}
+    if input_type == "dataframe":
+        labels = ["b", "a", "c"]
+
+        def to_data(groups):
+            return pd.DataFrame(
+                {
+                    "value": [value for group in groups for value in group],
+                    "group": [label for label, group in zip(labels, groups) for _ in group],
+                }
+            )
+
+        complete_data = to_data(samples)
+        padded_data = to_data(padded)
+        kwargs = {"val_col": "value", "group_col": "group"}
+    else:
+        complete_data = np.asarray(samples) if input_type == "array" else samples
+        padded_data = np.asarray(padded, dtype=object) if input_type == "array" else padded
+
+    expected = function(complete_data, sort=sort, **kwargs)
+    actual = function(padded_data, sort=sort, **kwargs)
+    pd.testing.assert_frame_equal(actual, expected)
+
+
+@pytest.mark.parametrize("function", RANK_POSTHOCS)
+def test_rank_posthoc_missing_group_matches_complete_input(function):
+    data = pd.DataFrame(
+        {
+            "value": [1, 2, 3, 4, 5, 6, 1000],
+            "group": ["a", "a", "a", "b", "b", "b", None],
+        }
+    )
+    expected = function(data.dropna(), val_col="value", group_col="group")
+    actual = function(data, val_col="value", group_col="group")
     pd.testing.assert_frame_equal(actual, expected)

--- a/tests/test_dunn_missing_values.py
+++ b/tests/test_dunn_missing_values.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pandas as pd
+import pytest
+from scipy.stats import mannwhitneyu
+
+from scikit_posthocs import posthoc_dunn
+
+
+@pytest.mark.parametrize("padding", [0, 1, 20])
+@pytest.mark.parametrize("input_type", ["list", "array", "dataframe"])
+@pytest.mark.parametrize("sort", [False, True])
+def test_dunn_missing_values_do_not_change_two_group_reference(padding, input_type, sort):
+    samples = [[1, 2, 2, 4, 5, 8], [3, 5, 5, 6, 9, 10]]
+    reference = mannwhitneyu(*samples, method="asymptotic", use_continuity=False).pvalue
+    padded = [group + [np.nan] * padding for group in samples]
+    kwargs = {}
+    if input_type == "dataframe":
+        data = pd.DataFrame(
+            {
+                "value": padded[0] + padded[1],
+                "group": ["b"] * len(padded[0]) + ["a"] * len(padded[1]),
+            }
+        )
+        kwargs = {"val_col": "value", "group_col": "group"}
+    else:
+        data = np.asarray(padded) if input_type == "array" else padded
+    actual = posthoc_dunn(data, sort=sort, **kwargs)
+    np.testing.assert_allclose(actual.iloc[0, 1], reference)
+
+
+def test_dunn_missing_group_is_excluded_before_ranking():
+    data = pd.DataFrame(
+        {"value": [1, 2, 3, 4, 5, 6, 1000], "group": ["a", "a", "a", "b", "b", "b", None]}
+    )
+    expected = posthoc_dunn(data.dropna(), val_col="value", group_col="group", p_adjust="holm")
+    actual = posthoc_dunn(data, val_col="value", group_col="group", p_adjust="holm")
+    pd.testing.assert_frame_equal(actual, expected)


### PR DESCRIPTION
`posthoc_dunn()` uses `len(x.index)` for the total sample size while pandas ranking, group counts and rank means exclude missing measured values. Blank entries therefore inflate only part of the formula. Missing group labels can also enter global ranks despite belonging to no valid comparison group.

Drop rows with a missing measured value or group label before ranking, counting and identifying groups. Document the exclusion. The non-missing observations and existing complete-data results are preserved.

On the 150-row iris sepal-width dataset, Holm-adjusted pairwise p-values are approximately `[2.047e-14, 1.537e-7, 0.01581]`. Adding 50 NaN placeholders per group changes them to `[0.000306, 0.01465, 0.22853]`; adding 500 per group changes all three to 1. No measured value changes. The correction gives the original results for each representation and agrees with a separate scalar Dunn/ Holm calculation. This is a controlled padding check on released data, not a claim about an original published analysis.

Validation on base `f59c84509515a4562f37a9048e0eeaf35f7af9c9`: 19 new cases cover missing-value padding, list/ndarray/DataFrame input, sort on/off and missing group labels. The two-group reference is SciPy's asymptotic Mann–Whitney test without continuity correction, which equals Dunn's two-group statistic including ties. Before: 13 fail, six pass. After: all 19 new cases pass, and the `-k dunn` selection including existing tests gives **23 passed**, 92 deselected. Released 0.16.1 also reproduces the error. Full package suite not run.

Prepared with AI assistance. Independent review and maintainer acceptance are not claimed. The [Cheerful Duck report](https://cheerfulduck.com/research/audits/scikit-posthocs-dunn-missing-values) provides the reproduction script, separate patches, environment records and before/after execution evidence in a downloadable archive.
